### PR TITLE
Add MySQL install and starting market cap tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
 # Pump.fun Tracker
 
 Modular data ingestion, coin monitoring, and trading logic for Pump.fun.
+
+## Features
+
+- Automatically installs dependencies and MySQL server on startup.
+- Records the starting market cap for each newly discovered token.

--- a/db/database.py
+++ b/db/database.py
@@ -27,7 +27,8 @@ def setup_database(conn):
             show_name BOOLEAN,
             nsfw BOOLEAN,
             is_currently_live BOOLEAN,
-            complete BOOLEAN
+            complete BOOLEAN,
+            starting_market_cap DOUBLE
         )
     """)
 

--- a/models/fields.py
+++ b/models/fields.py
@@ -2,7 +2,8 @@ IMMUTABLE_FIELDS = [
     "mint", "name", "symbol", "description", "image_uri", "metadata_uri",
     "twitter", "telegram", "website", "creator",
     "bonding_curve", "associated_bonding_curve", "created_timestamp",
-    "total_supply", "show_name", "nsfw", "is_currently_live", "complete"
+    "total_supply", "show_name", "nsfw", "is_currently_live", "complete",
+    "starting_market_cap"
 ]
 
 MUTABLE_FIELDS = [

--- a/startup.sh
+++ b/startup.sh
@@ -2,6 +2,9 @@
 
 cd "$(dirname "$0")"
 
+echo "🔄 Updating package lists..."
+sudo apt-get update -y
+
 echo "🔄 Setting up virtual environment..."
 
 # Create virtual environment if it doesn't exist
@@ -25,8 +28,8 @@ fi
 # MySQL check and bootstrap
 echo "🔍 Checking MySQL installation..."
 if ! command -v mysql &> /dev/null; then
-  echo "❌ MySQL is not installed. Please install it: sudo apt install mysql-server"
-  exit 1
+  echo "❌ MySQL is not installed. Installing..."
+  sudo apt-get install -y mysql-server
 fi
 
 echo "🧠 Verifying if database and user exist..."

--- a/update/update_new_coins.py
+++ b/update/update_new_coins.py
@@ -1,4 +1,4 @@
-from api.coins import get_recent_mints
+from api.coins import get_recent_mints, fetch_coin_details
 from db.database import coin_exists, insert_immutable
 from utils.logger import log
 
@@ -9,5 +9,13 @@ def update_new_coins(conn):
         if not mint:
             continue
         if not coin_exists(conn, mint):
+            details = fetch_coin_details(mint)
+            if details and details.get("market_cap") is not None:
+                coin["starting_market_cap"] = details.get("market_cap")
             insert_immutable(conn, coin)
-            log(f"New coin added: {coin.get('symbol')} ({mint})")
+            log(
+                f"New coin added: {coin.get('symbol')} ({mint})"
+                + (
+                    f" starting market cap {coin.get('starting_market_cap')}" if coin.get('starting_market_cap') is not None else ""
+                )
+            )


### PR DESCRIPTION
## Summary
- update `startup.sh` to update package lists and install mysql-server when missing
- record starting market cap for each new token
- include new `starting_market_cap` column in DB schema
- document features in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`
- `bash -n startup.sh`


------
https://chatgpt.com/codex/tasks/task_e_688b9e10bed88326ae39f0d31295ba11